### PR TITLE
Fixing App Insight location to follow RG's location

### DIFF
--- a/Hands-on lab/HOL step-by-step - Continuous delivery in Azure DevOps.md
+++ b/Hands-on lab/HOL step-by-step - Continuous delivery in Azure DevOps.md
@@ -167,6 +167,8 @@ Since this solution is based on Azure Platform-as-a-Service (PaaS) technology, i
 1.  Add a new resource to the template, this time choose **Application Insights for Web Apps**. Make sure your correct hosting plan and web app are selected in the boxes. Name the Application Insights resource "TailspinToysWeb" and then click **Add**.
     
     ![In the Add Resource window, Application Insights for Web App is highlighted on the left, TailspinToysWeb is highlighted next to that in the Name box, and Add is highlighted at the bottom.](images/stepbystep/media/image33.png "Add Resource window")
+    
+    Notice that the json file has been modified. Navigate to the JSON Editor and change the "location": "East US", to "location": "[resourceGroup().location]".
 
 2.  Next, you need to add the Application Insights extension to the App Service so that it will be running automatically once the site is deployed. This is going to require some manual code because there is not a wizard for this resource type. Click on the TailspinToysWeb web app resource to locate its JSON code. Then, just below the "properties" property, paste or type in this block of JSON code.
     ```


### PR DESCRIPTION
By default, it places App Insight to East US. This fix is to provide manual changes to the json file.